### PR TITLE
Stamp dlw

### DIFF
--- a/R/attach.R
+++ b/R/attach.R
@@ -1,7 +1,18 @@
 # This is basically a copy of tidyverse and tidymodels
 
 # Dropping pipr from this core packages as it is not available under PIP-Technical-Team
-core <- c("pipapi", "pipload", "wbpip", "pipfun", "pipdata", "pipster", "pipaux","pipfaker")
+core <- c(
+  "pipapi",
+  "pipload",
+  "wbpip",
+  "pipfun",
+  "pipdata",
+  "pipster",
+  "pipaux",
+  "pipfaker",
+  "dlw",
+  "stamp"
+)
 
 pkg_loaded <- function(pkg = NULL) {
   if (is.null(pkg)) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,12 +15,14 @@ is_attached <- function(x) {
 }
 
 metapip_default_options <- list(
-  metapip.default_branch = "DEV_v2",
+  metapip.default_branch = "PROD",
   metapip.custom_branch = list(
     pipapi_branch = "DEV",
     pipfaker_branch = "main",
     wbpip_branch = "DEV",
-    pipster_branch = "DEV"
+    pipster_branch = "DEV",
+    stamp_branch = "main",
+    dlw_branch = "main"
   )
 )
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -35,7 +35,10 @@ The core PIP R packages are
 -   wbpip
 -   pipfun
 -   pipdata
--   pipr
+-   pipster
+-   pipfaker
+-   dlw
+-   stamp
 
 ## Installation
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -51,7 +51,7 @@ devtools::install_github("PIP-Technical-Team/metapip")
 
 ## Setting up default branch in metapip
 
-In `metapip` there are different ways to set up default branches. By default it uses `options(metapip.default_branch)` to provide a default branch value to all packages. When you load the package it is set to "DEV_v2". You can override that default setting on per package basis by updating options with custom default branch like `options(metapip.custom_branch = list(pipapi_branch = "DEV", pipfaker_branch = "main"))`. So in this case, the default value for `pipapi` branch is "DEV" whereas the one for `pipfaker` is set to "main". For rest of the pip core packages it remains as "DEV_v2". 
+In `metapip` there are different ways to set up default branches. By default it uses `options(metapip.default_branch)` to provide a default branch value to all packages. When you load the package it is set to "PROD". You can override that default setting on per package basis by updating options with custom default branch like `options(metapip.custom_branch = list(pipapi_branch = "DEV", pipfaker_branch = "main"))`. So in this case, the default value for `pipapi`, `wbpip` and `pipster` branch is "DEV" whereas the one for `pipfaker`,`stamp` and `dlw` is set to "main". For rest of the pip core packages it remains as "PROD". 
 
 ## Functions and it's usage in metapip
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ The core PIP R packages are
 - wbpip
 - pipfun
 - pipdata
-- pipr
+- pipster
+- pipfaker
+- dlw
+- stamp
 
 ## Installation
 
@@ -53,12 +56,12 @@ devtools::install_github("PIP-Technical-Team/metapip")
 In `metapip` there are different ways to set up default branches. By
 default it uses `options(metapip.default_branch)` to provide a default
 branch value to all packages. When you load the package it is set to
-“DEV_v2”. You can override that default setting on per package basis by
+“PROD”. You can override that default setting on per package basis by
 updating options with custom default branch like
 `options(metapip.custom_branch = list(pipapi_branch = "DEV", pipfaker_branch = "main"))`.
-So in this case, the default value for `pipapi` branch is “DEV” whereas
-the one for `pipfaker` is set to “main”. For rest of the pip core
-packages it remains as “DEV_v2”.
+So in this case, the default value for `pipapi`, `wbpip` and `pipster`
+branch is “DEV” whereas the one for `pipfaker`,`stamp` and `dlw` is set
+to “main”. For rest of the pip core packages it remains as “PROD”.
 
 ## Functions and it’s usage in metapip
 


### PR DESCRIPTION
Hola @randrescastaneda,

I wanted to add stamp to the metapip packages, but I thought to add as well to add dlw. Also, since now we are using PROD as the main branch (Tefera already merged the last changes to this branch), then I made it the default branch. If you do not agree to any of these changes, I can change it accordingly. Thank you for reviewing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Core managed packages expanded to include dlw and stamp alongside existing pip-* packages.
  * Added per-package branch settings for dlw and stamp (both set to main).

* **Changes**
  * Default branch value changed from DEV_v2 to PROD.

* **Documentation**
  * README updated to reflect new core packages and revised default-branch examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->